### PR TITLE
Infra Update: New Release Provenance Database and Workflow Triggers

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@main
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v5
     with:
       model: ${{ vars.NAME }}
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   pr-ci:
     name: CI
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@main
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v5
     with:
       model: ${{ vars.NAME }}
       # root-sbd: if different from vars.NAME
@@ -35,7 +35,7 @@ jobs:
   pr-comment:
     name: Comment
     if: github.event_name == 'issue_comment'
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@main
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v5
     with:
       model: ${{ vars.NAME }}
       # root-sbd: if different from vars.NAME
@@ -46,7 +46,7 @@ jobs:
   pr-closed:
     name: Closed
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@main
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v5
     with:
       model: ${{ vars.NAME }}
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,3 @@
-# Requires vars.NAME to be set as a variable.
 name: CI
 on:
   pull_request:
@@ -22,14 +21,17 @@ on:
 jobs:
   pr-ci:
     name: CI
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    if: >-
+      (github.event_name == 'pull_request' && github.event.action != 'closed') ||
+      (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!redeploy'))
     uses: access-nri/build-cd/.github/workflows/ci.yml@v5
     with:
       model: ${{ vars.NAME }}
-      # root-sbd: if different from vars.NAME
+      pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}
     permissions:
       pull-requests: write
       contents: write
+      statuses: write
     secrets: inherit
 
   pr-comment:
@@ -38,15 +40,15 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v5
     with:
       model: ${{ vars.NAME }}
-      # root-sbd: if different from vars.NAME
     permissions:
       pull-requests: write
       contents: write
+    secrets: inherit
 
   pr-closed:
     name: Closed
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v5
     with:
-      model: ${{ vars.NAME }}
+      root-sbd: ${{ vars.NAME }}
     secrets: inherit


### PR DESCRIPTION
References issue https://github.com/ACCESS-NRI/build-cd/issues/263 and PR https://github.com/ACCESS-NRI/build-cd/issues/269
References issue https://github.com/ACCESS-NRI/build-cd/issues/238

> [!IMPORTANT]
> This PR is a major update to the deployment infrastructure. See below for the prerequisites for this repository to be able to merge this PR.

## Background

This Infrastructure update moves away from the old build database at https://experiment-metadb-seven.vercel.app/release-provenance to a more modern database as part of `ACCESS-NRI/tracking_services`, at https://reporting-dev.access-nri-store.cloud.edu.au/release-provenance/releases.

We also allow rebuilding of prereleases `on.pull_request.types.ready_for_review` and `on.pull_request.types.converted_to_draft`, which removes a small but significant loophole in which someone works on a draft PR (with less restrictive `spack.yaml` checks) and then converts it to Ready For Review.

## Prerequisites for Merging

- [x] Update `build-cd` entrypoints (this PR!)
- [x] Update triggers (also this PR!)
- [x] Delete Repo Secret `secrets.BUILD_DB_CONNECTION_STR` (from the old build database)
- [x] Add GitHub Environment (`* Release`) Variable `vars.TRACKING_SERVICES_POST_URL` (URL for posting release data)
- [x] Add GitHub Environment (`* Release`) Secret `secrets.TRACKING_SERVICES_POST_TOKEN` (Token for posting release data)