### PR TITLE
Update CABLE files within JULES as precursor to CABLE as library

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.09.004"
+    "spack-packages": "9a8d2ce8ae5352d0ffbf3030877cbd8fec54e5ce"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 spack:
   specs:
-    - access-am3@git.2025.10.000
+    - access-am3@git.2025.12.000
   packages:
     # Direct dependencies
     um:

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
       require:
         - '@13.1'
         - model="vn13p1-am"
-        - jules_ref="2025.08.0"
+        - jules_ref="update-cable"
         - um_ref="2025.08.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
       require:
         - '@13.1'
         - model="vn13p1-am"
-        - jules_ref="7632dfc1baef59cc9d9bc94184a7675e3d06c930"
+        - jules_ref="db84dcaa8ac576ea93de2d025c9a70f07ab72894"
         - um_ref="2025.08.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
       require:
         - '@13.1'
         - model="vn13p1-am"
-        - jules_ref="c8545d505d0a2fb8c397728c23cc222c1da23de8"
+        - jules_ref="867f7f9e278e0c89b0833d07ebbed6938bac179d"
         - um_ref="2025.08.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
       require:
         - '@13.1'
         - model="vn13p1-am"
-        - jules_ref="599cc10f2a27f4d7136ed44fd7a396fbfac4c6d0"
+        - jules_ref="36fb0e84c32d0d226b9aa83fe74ee9bc45c313a1"
         - um_ref="2025.08.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
       require:
         - '@13.1'
         - model="vn13p1-am"
-        - jules_ref="f3aa566fe3a6fb74419ab80a77b644e0998cc5ea"
+        - jules_ref="748c9822a6d5df081528328f77ce72244e362ec5"
         - um_ref="2025.08.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
       require:
         - '@13.1'
         - model="vn13p1-am"
-        - jules_ref="0912ce2a4a789b3c99a47d1a1e9cadb873ba090c"
+        - jules_ref="7632dfc1baef59cc9d9bc94184a7675e3d06c930"
         - um_ref="2025.08.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
       require:
         - '@13.1'
         - model="vn13p1-am"
-        - jules_ref="db84dcaa8ac576ea93de2d025c9a70f07ab72894"
+        - jules_ref="e71e28fd61f3ec00021556c2b176321843955767"
         - um_ref="2025.08.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
       require:
         - '@13.1'
         - model="vn13p1-am"
-        - jules_ref="1bdf30b3116579a7f2fdd42eb1ae75c9561b349b"
+        - jules_ref="c8545d505d0a2fb8c397728c23cc222c1da23de8"
         - um_ref="2025.08.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
       require:
         - '@13.1'
         - model="vn13p1-am"
-        - jules_ref="748c9822a6d5df081528328f77ce72244e362ec5"
+        - jules_ref="599cc10f2a27f4d7136ed44fd7a396fbfac4c6d0"
         - um_ref="2025.08.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
       require:
         - '@13.1'
         - model="vn13p1-am"
-        - jules_ref="36fb0e84c32d0d226b9aa83fe74ee9bc45c313a1"
+        - jules_ref="0912ce2a4a789b3c99a47d1a1e9cadb873ba090c"
         - um_ref="2025.08.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
       require:
         - '@13.1'
         - model="vn13p1-am"
-        - jules_ref="e71e28fd61f3ec00021556c2b176321843955767"
+        - jules_ref="683920a56378eaed81c9216d734aa207f47e0377"
         - um_ref="2025.08.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
       require:
         - '@13.1'
         - model="vn13p1-am"
-        - jules_ref="update-cable"
+        - jules_ref="1bdf30b3116579a7f2fdd42eb1ae75c9561b349b"
         - um_ref="2025.08.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
       require:
         - '@13.1'
         - model="vn13p1-am"
-        - jules_ref="867f7f9e278e0c89b0833d07ebbed6938bac179d"
+        - jules_ref="f3aa566fe3a6fb74419ab80a77b644e0998cc5ea"
         - um_ref="2025.08.0"
 
     # Indirect dependencies


### PR DESCRIPTION
Try to update the CABLE files within JULES

---
:rocket: The latest prerelease `access-am3/pr17-15` at f1ca73d444a53f52bd7d59f0d825a2bc1aa9a7aa is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/17#issuecomment-3782128504 :rocket:















