### PR TITLE
Use GitHub UKMO components

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "743214a989221d1723085d38671aa68add60ccbb"
+    "spack-packages": "381aaf345f95e9ed712fc7a4f50d54f5e977c628"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "7eabff3fc91d96296e3412e4d6cfc545cdfe0e28"
+    "spack-packages": "26e2087907046c15f4c048ee64d2e60f4dee54c5"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "381aaf345f95e9ed712fc7a4f50d54f5e977c628"
+    "spack-packages": "ba20703fa66db5f0440ace1da29d2c172b68b18b"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.09.004"
+    "spack-packages": "7eabff3fc91d96296e3412e4d6cfc545cdfe0e28"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "26e2087907046c15f4c048ee64d2e60f4dee54c5"
+    "spack-packages": "743214a989221d1723085d38671aa68add60ccbb"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "ba20703fa66db5f0440ace1da29d2c172b68b18b"
+    "spack-packages": "c0f985e01da7d9394020e3a8def8edd8aa270077"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "c0f985e01da7d9394020e3a8def8edd8aa270077"
+    "spack-packages": "89c89776168de2d006d8ef805bc3268498c96afc"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "b7f8205ae1de2eb04584febc2d6d28ff9b4d6183"
+    "spack-packages": "7ca1037d047c031d50d886c095736fb001897ad2"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "89c89776168de2d006d8ef805bc3268498c96afc"
+    "spack-packages": "b7f8205ae1de2eb04584febc2d6d28ff9b4d6183"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 spack:
   specs:
-    - access-am3@git.2026.03.000
+    - access-am3@git.2026.02.001
   packages:
     # Direct dependencies
     um:

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,10 +13,10 @@ spack:
         - model="vn13p1-am"
         - jules_ref="2026.01.0"
         - um_ref="2025.08.0"
-        - ukca_ref="vn13.1"
-        - shumlib_ref="vn13.1"
-        - socrates_ref="vn13.1"
-        - casim_ref="vn13.1"
+        - ukca_ref="615a547a060ef80ae6019cf63d409602473e1e68"
+        - shumlib_ref="um13.1"
+        - socrates_ref="um13.1"
+        - casim_ref="um13.1"
 
     # Indirect dependencies
     netcdf-c:

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,7 +13,7 @@ spack:
         - model="vn13p1-am"
         - jules_ref="2025.08.0"
         - um_ref="2025.08.0"
-        - ukca_ref="2025.12.1"
+        - ukca_ref="615a547a060ef80ae6019cf63d409602473e1e68"
 
     # Indirect dependencies
     netcdf-c:

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,10 +13,10 @@ spack:
         - model="vn13p1-am"
         - jules_ref="2026.01.0"
         - um_ref="2025.08.0"
-        - ukca_ref="615a547a060ef80ae6019cf63d409602473e1e68"
-        - shumlib_ref="82270fe80d6550c63935452820fe0e0888a2141e"
-        - socrates_ref="9f6aec2a1d4d7fa27fe7f7afa542b88410056431"
-        - casim_ref="02099a7cab7c1fc23f1cffaf098b34d0de47e95d"
+        - ukca_ref="vn13.1"
+        - shumlib_ref="vn13.1"
+        - socrates_ref="vn13.1"
+        - casim_ref="vn13.1"
 
     # Indirect dependencies
     netcdf-c:

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,7 +13,7 @@ spack:
         - model="vn13p1-am"
         - jules_ref="2025.08.0"
         - um_ref="2025.08.0"
-        - ukca_ref="2021.12.1"
+        - ukca_ref="2025.12.1"
 
     # Indirect dependencies
     netcdf-c:

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 spack:
   specs:
-    - access-am3@git.2026.02.000
+    - access-am3@git.2026.03.000
   packages:
     # Direct dependencies
     um:

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 spack:
   specs:
-    - access-am3@git.2025.10.000
+    - access-am3@git.2026.02.000
   packages:
     # Direct dependencies
     um:

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,6 +13,7 @@ spack:
         - model="vn13p1-am"
         - jules_ref="2025.08.0"
         - um_ref="2025.08.0"
+        - ukca_ref="2021.12.1"
 
     # Indirect dependencies
     netcdf-c:

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,6 +14,9 @@ spack:
         - jules_ref="2026.01.0"
         - um_ref="2025.08.0"
         - ukca_ref="615a547a060ef80ae6019cf63d409602473e1e68"
+        - shumlib_ref="82270fe80d6550c63935452820fe0e0888a2141e"
+        - socrates_ref="9f6aec2a1d4d7fa27fe7f7afa542b88410056431"
+        - casim_ref="02099a7cab7c1fc23f1cffaf098b34d0de47e95d"
 
     # Indirect dependencies
     netcdf-c:


### PR DESCRIPTION
Now that the Met office has switched to Github, we can use Github repositories for the various components we used to pull from the MOSRS mirror. Uses GCOM, Socrates, UKCA, casim and shumlib from Github.

Confirmed that the release AM3 configuration gets bitwise identical results, for the first few months of NetCDF data.

---
:rocket: The latest prerelease `access-am3/pr25-3` at fc2db5860a4b57628b6361063d575ea8cbef4f80 is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/25#issuecomment-3911199704 :rocket:





---
:rocket: The latest prerelease `access-am3/pr25-7` at 6ea22a1751e6b19ad2b3851f382a20f33706222e is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/25#issuecomment-3917751639 :rocket:



