### PR TITLE
Investigate namelist differences

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
       require:
         - '@13.1'
         - model="vn13p1-am"
-        - jules_ref="00e5b4016327e68e8a462dc32f957dcfed825507"
+        - jules_ref="f4b0cfa7b3480df94797a9633555f550e0c35da0"
         - um_ref="2026.01.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
       require:
         - '@13.1'
         - model="vn13p1-am"
-        - jules_ref="9d1725433900c3755157c44313b7af0d2a8a688f"
+        - jules_ref="00e5b4016327e68e8a462dc32f957dcfed825507"
         - um_ref="2026.01.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,14 +4,14 @@
 # configuration settings.
 spack:
   specs:
-    - access-am3@git.2026.02.000
+    - access-am3@git.2026.03.000
   packages:
     # Direct dependencies
     um:
       require:
         - '@13.1'
         - model="vn13p1-am"
-        - jules_ref="2026.01.0"
+        - jules_ref="9d1725433900c3755157c44313b7af0d2a8a688f"
         - um_ref="2026.01.0"
 
     # Indirect dependencies


### PR DESCRIPTION
Jhan is currently trying to implement reading of a namelist for major configuration options. Found some very strange behaviour- seems that `cable_user%l_revise_coupling` is not what it's expected to be on a single step on a single processor? [See JULES thread](https://github.com/ACCESS-NRI/JULES/pull/328). Doing some digging to see if I can work out what's going on, and some tracking of what we've tested.

---
:rocket: The latest prerelease `access-am3/pr28-3` at fbb486c1e390c1a340bbb57185e67c299ba7c3cc is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/28#issuecomment-4028833512 :rocket:


