### PR TITLE
Update JULES and UM versions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,11 +10,11 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v7
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v8
     with:
       model: ${{ vars.NAME }}
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       contents: write

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -8,12 +8,11 @@ jobs:
   redeploy:
     name: Redeploy
     if: startsWith(github.event.comment.body, '!redeploy') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
-      pr: ${{ github.event.issue.number }}
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       pull-requests: write
@@ -23,7 +22,7 @@ jobs:
   bump:
     name: Bump
     if: startsWith(github.event.comment.body, '!bump') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v8
     with:
       model: ${{ vars.NAME }}
     permissions:
@@ -33,7 +32,7 @@ jobs:
   configs:
     name: Configs
     if: startsWith(github.event.comment.body, '!update-configs') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v8
     with:
       model: ${{ vars.NAME }}
       auto-configs-pr-schema-version: 1-0-0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,12 @@ on:
 jobs:
   pr-ci:
     name: CI
-    if: >-
-      github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
+    if: github.event.action != 'closed'
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
-      pr: ${{ github.event.pull_request.number }}
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       pull-requests: write
@@ -34,7 +32,5 @@ jobs:
   pr-closed:
     name: Closed
     if: github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v7
-    with:
-      root-sbd: ${{ vars.NAME }}
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
     secrets: inherit

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,8 @@
 {
-    "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
-    "spack": "0.22",
-    "spack-packages": "2025.09.004"
+  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
+  "spack": "1.1",
+  "access-spack-packages": "2026.03.005",
+  "custom-scopes": [
+    "ukmo-restricted-scope"
+  ]
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
       - model="vn13p1-am"
       - jules_ref="2026.03.0"
       - um_ref="2026.03.0"
-      - ukca_ref="615a547a060ef80ae6019cf63d409602473e1e68"
+      - ukca_ref="AM3-2026.03.0"
 
     # Indirect dependencies
     netcdf-c:

--- a/spack.yaml
+++ b/spack.yaml
@@ -3,51 +3,59 @@
 # It describes a set of packages to be installed, along with
 # configuration settings.
 spack:
+  definitions:
+  # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
+  - _name: [access-am3]
+  - _version: [2026.02.000]
   specs:
-    - access-am3@git.2026.02.000
+  - access-am3
   packages:
     # Direct dependencies
     um:
       require:
-        - '@13.1'
-        - model="vn13p1-am"
-        - jules_ref="2026.01.0"
-        - um_ref="2026.01.0"
+      - '@13.1'
+      - model="vn13p1-am"
+      - jules_ref="2026.01.0"
+      - um_ref="2026.01.0"
+      - ukca_ref="615a547a060ef80ae6019cf63d409602473e1e68"
 
     # Indirect dependencies
     netcdf-c:
       require:
-        - '@4.9.2'
+      - '@4.9.2'
 
     netcdf-fortran:
       require:
-        - '@4.5.2'
+      - '@4.5.2'
 
     fcm:
       require:
-        - '@2021.05.0'
-        # TODO: Generalize this Gadi-specific variant for spack.yaml
-        - 'site=nci-gadi'
+      - '@2021.05.0'
+      # TODO: Generalize this Gadi-specific variant for spack.yaml
+      - 'site=nci-gadi'
 
     gcom:
       require:
-        - '@7.9'
+      - '@7.9'
 
     openmpi:
       require:
-        - '@4.1.7'
+      - '@4.1.7'
+    # Compilers
+    c:
+      require:
+      - intel-oneapi-compilers-classic@2021.10.0
+    cxx:
+      require:
+      - intel-oneapi-compilers-classic@2021.10.0
+    fortran:
+      require:
+      - intel-oneapi-compilers-classic@2021.10.0
 
     # Specifications that apply to all packages
     all:
       require:
-        - '%intel@2021.10.0'
-        - target=x86_64_v4
+      - target=x86_64_v4
   view: true
   concretizer:
     unify: true
-  config:
-    install_tree:
-      root: $spack/../restricted/ukmo/release
-    source_cache: $spack/../restricted/ukmo/source_cache
-    build_stage:
-    - $TMPDIR/restricted/spack-stage

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,15 +4,15 @@
 # configuration settings.
 spack:
   specs:
-    - access-am3@git.2026.02.000
+    - access-am3@git.2026.03.000
   packages:
     # Direct dependencies
     um:
       require:
         - '@13.1'
         - model="vn13p1-am"
-        - jules_ref="2026.01.0"
-        - um_ref="2026.01.0"
+        - jules_ref="2026.03.0"
+        - um_ref="2026.03.0"
 
     # Indirect dependencies
     netcdf-c:

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.02.000]
+  - _version: [2026.03.000]
   specs:
   - access-am3
   packages:
@@ -15,8 +15,8 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="2026.01.0"
-      - um_ref="2026.01.0"
+      - jules_ref="2026.03.0"
+      - um_ref="2026.03.0"
       - ukca_ref="615a547a060ef80ae6019cf63d409602473e1e68"
 
     # Indirect dependencies


### PR DESCRIPTION
Updates on both model components for increased number of diagnostics, supporting Jiachen's urban work, and adding a namelist for CABLE.

---
:rocket: The latest prerelease `access-am3/pr32-5` at 4f0a5ff21c3349b18b465192dca1b7b980000125 is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/32#issuecomment-4218954950 :rocket:




