### PR TITLE
Point to a UKCA tag instead of a commit hash

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
       - model="vn13p1-am"
       - jules_ref="2026.01.0"
       - um_ref="2026.01.0"
-      - ukca_ref="615a547a060ef80ae6019cf63d409602473e1e68"
+      - ukca_ref="2026.03.0"
 
     # Indirect dependencies
     netcdf-c:


### PR DESCRIPTION
Points to the UKCA tag which is the current head of the `um13.1_blackcarbon_cable_deposition` branch, which contains the changes required for CABLE. There is no functional change- the `2026.03.0` tag points to the same commit as is used currently.

---
:rocket: The latest prerelease `access-am3/pr33-1` at 7e36627dc59b20e923d490584b0f1eb613cd1d82 is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/33#issuecomment-4195862330 :rocket:
