### PR TITLE
update component refs to 2026.03.0

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,6 @@ spack:
   - access-am3
   packages:
     # Direct dependencies
-    # Add a nonsense comment
     um:
       require:
       - '@13.1'

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,6 +11,7 @@ spack:
   - access-am3
   packages:
     # Direct dependencies
+    # Add a nonsense comment
     um:
       require:
       - '@13.1'

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.02.000]
+  - _version: [2026.03.000]
   specs:
   - access-am3
   packages:
@@ -15,9 +15,9 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="2026.01.0"
-      - um_ref="2026.01.0"
-      - ukca_ref="615a547a060ef80ae6019cf63d409602473e1e68"
+      - jules_ref="2026.03.0"
+      - um_ref="2026.03.0"
+      - ukca_ref="AM3-2026.03.0"
 
     # Indirect dependencies
     netcdf-c:


### PR DESCRIPTION
This is a retry of #32, since it was having persistent `openmpi` problems. Closing that PR should clear the build cache of those builds, and force it to attempt to rebuild.

---
:rocket: The latest prerelease `access-am3/pr34-6` at ad202660bdf68c2cf9c82554c829309cbc6a2f1e is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/34#issuecomment-4241408780 :rocket:





