### PR TITLE
Re-deploy 2026.03.000 After Workflow Error

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,8 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v8
+    # NOTE: We are using this specific tag of the deployment infra as the current HEAD of v8 works with a new spack-config that isn't yet migrated to the release instance.  
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v8.3.3
     with:
       model: ${{ vars.NAME }}
       spack-manifest-schema-version: 2-0-0

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,4 +1,4 @@
-# This is a Spack Environment file.
+# This is a Spack Environment file!
 #
 # It describes a set of packages to be installed, along with
 # configuration settings.


### PR DESCRIPTION
Redeploy of #34

## Background

On the infrastructure side of things, we're currently updating our spack instances to use a new version of `spack-config`. The workflow can handle it for prerelease, but we haven't yet got around to it working for release instances. This temporary tag for `build-cd` will be used to deploy the above `2026.03.000` release while we migrate the release instances. 

## The PR

* See linked PR
