### PR TITLE
Update UM and JULES for CABLE science update

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.03.000]
+  - _version: [2026.05.000]
   specs:
   - access-am3
   packages:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
       - '@13.1'
       - model="vn13p1-am"
       - jules_ref="2026.05.0"
-      - um_ref="test-tag"
+      - um_ref="2026.05.0"
       - ukca_ref="AM3-2026.03.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,8 +15,8 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="2026.03.0"
-      - um_ref="2026.03.0"
+      - jules_ref="2026.05.0"
+      - um_ref="15d105a466fed5fb16e32c62e58061c2c37d517c"
       - ukca_ref="AM3-2026.03.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
       - '@13.1'
       - model="vn13p1-am"
       - jules_ref="2026.05.0"
-      - um_ref="15d105a466fed5fb16e32c62e58061c2c37d517c"
+      - um_ref="test-tag"
       - ukca_ref="AM3-2026.03.0"
 
     # Indirect dependencies


### PR DESCRIPTION
This brings in the recent update of CABLE science to the deployed executable. This was originally waiting for a spack packages PR to add the required `UM_CBL` preprocessor directive to the build config. However, this will not fix the FCM build as noted by @JhanSrbinovsky. Adding this directive to the UM build config will solve the temporary problem for both the spack and FCM builds (problem is temporary as when CABLE comes in as a library, that directive will be defined when the library is built).

---
:rocket: The latest prerelease `access-am3/pr37-4` at ed7cd7bca57de1eeba5001ba1f39fb026e0e3983 is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/37#issuecomment-4505833677 :rocket:




