### PR TITLE
Set UM to a commit ref

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "37081f0d6b1fc1f6f74067aede1d8ce304257c14",
+  "access-spack-packages": "256020f0637cc9ef57f9fe5e27ac9d7d7f438623",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "256020f0637cc9ef57f9fe5e27ac9d7d7f438623",
+  "access-spack-packages": "2026.05.005",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.03.005",
+  "access-spack-packages": "75d32055311dc53df8e27fabcdd05da2a1aa862c",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "75d32055311dc53df8e27fabcdd05da2a1aa862c",
+  "access-spack-packages": "37081f0d6b1fc1f6f74067aede1d8ce304257c14",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
       - '@13.1'
       - model="vn13p1-am"
       - jules_ref="2026.05.0"
-      - um_ref="2026.05.0"
+      - um_ref="b640c70cb4b77e061969286b4a8bf486b3b47364"
       - ukca_ref="AM3-2026.03.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
       - '@13.1'
       - model="vn13p1-am"
       - jules_ref="2026.05.0"
-      - um_ref="aa8375a72f2b6cd2afdd4abcbaedffd856698d10"
+      - um_ref="2026.05.0"
       - ukca_ref="AM3-2026.03.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.05.000]
+  - _version: [2026.05.001]
   specs:
   - access-am3
   packages:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
       - '@13.1'
       - model="vn13p1-am"
       - jules_ref="2026.05.0"
-      - um_ref="b640c70cb4b77e061969286b4a8bf486b3b47364"
+      - um_ref="aa8375a72f2b6cd2afdd4abcbaedffd856698d10"
       - ukca_ref="AM3-2026.03.0"
 
     # Indirect dependencies


### PR DESCRIPTION
@bschroeter The UM build system was failing to fetch UM specifically from commit refs. This updates the `spack-packages` version to include that fix.

---
:rocket: The latest prerelease `access-am3/pr38-6` at 31670b616c2ae72dae5e510ae20131e8c143a38e is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/38#issuecomment-4530613272 :rocket:








---
:rocket: The latest prerelease `access-am3/pr38-7` at ca72671c01b1a2193b896c2475d797a60cff83cf is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/38#issuecomment-4598088627 :rocket:
