### PR TITLE
Update shumlib with extrapolation fix

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.05.000]
+  - _version: [2026.05.001]
   specs:
   - access-am3
   packages:
@@ -18,6 +18,7 @@ spack:
       - jules_ref="2026.05.0"
       - um_ref="2026.05.0"
       - ukca_ref="AM3-2026.03.0"
+      - shumlib_ref="6adf418acdd62322f40e6ab31a9de36c59b24bfb"
 
     # Indirect dependencies
     netcdf-c:

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.05.001]
+  - _version: [2026.06.002]
   specs:
   - access-am3
   packages:
@@ -18,7 +18,7 @@ spack:
       - jules_ref="2026.05.0"
       - um_ref="2026.05.0"
       - ukca_ref="AM3-2026.03.0"
-      - shumlib_ref="6adf418acdd62322f40e6ab31a9de36c59b24bfb"
+      - shumlib_ref="2026.06.0"
 
     # Indirect dependencies
     netcdf-c:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="2026.05.0"
+      - jules_ref="2026.06.0"
       - um_ref="2026.05.0"
       - ukca_ref="AM3-2026.03.0"
       - shumlib_ref="2026.06.0"


### PR DESCRIPTION
Pao identified a bug in the code at n512e resolution [here](https://github.com/ACCESS-NRI/access-am3-configs/issues/201). Martin made a fix on [this branch]( https://github.com/ACCESS-NRI/shumlib/commits/um13.1-bilinear-fix/) of `shumlib` but it hasn't been merged yet. W21C are using this update for their high-res runs.

---
:rocket: The latest prerelease `access-am3/pr39-2` at 2d901ea88153739394383955391013b4ba12b413 is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/39#issuecomment-4776587340 :rocket:

