### PR TITLE
Change the cable_surface_types_mod for CABLE library

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "0e38431c4c04a65affc68dbe835b0ed811d20489",
+  "access-spack-packages": "2026.05.000",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.03.005",
+  "access-spack-packages": "0e38431c4c04a65affc68dbe835b0ed811d20489",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="bfaec9470846a539efd3fce7464446cb565be13b"
+      - jules_ref="baec8c5b5881d75aff25b0ac7af64adbdc4e193d"
       - um_ref="2026.05.0"
       - ukca_ref="AM3-2026.03.0"
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="34a09ccfa236b40b13773d069bf4aa36bd9c25b2"
+      - jules_ref="74827509f9edfef388afd27a669c01a71f2d5698"
       - um_ref="2026.05.0"
       - ukca_ref="AM3-2026.03.0"
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="50db5bccba1df7ed0bd873d5d5c6211881508a1a"
+      - jules_ref="34a09ccfa236b40b13773d069bf4aa36bd9c25b2"
       - um_ref="2026.05.0"
       - ukca_ref="AM3-2026.03.0"
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="74827509f9edfef388afd27a669c01a71f2d5698"
+      - jules_ref="2026.06.1"
       - um_ref="2026.05.0"
       - ukca_ref="AM3-2026.03.0"
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.06.000]
+  - _version: [2026.06.001]
   specs:
   - access-am3
   packages:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="00716348bb4f79b3a4e5dcc4479f365f786aeff4"
+      - jules_ref="0734d12dc621f9095050ec2597c93b61ab4fc36d"
       - um_ref="2026.05.0"
       - ukca_ref="AM3-2026.03.0"
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="baec8c5b5881d75aff25b0ac7af64adbdc4e193d"
+      - jules_ref="c4b29e9391a5970232b2ccfd60ed4da6204659ad"
       - um_ref="2026.05.0"
       - ukca_ref="AM3-2026.03.0"
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="c4b29e9391a5970232b2ccfd60ed4da6204659ad"
+      - jules_ref="50db5bccba1df7ed0bd873d5d5c6211881508a1a"
       - um_ref="2026.05.0"
       - ukca_ref="AM3-2026.03.0"
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="0b6717ebd65c5228c2cae7574b6a80454f6f9ad6"
+      - jules_ref="00716348bb4f79b3a4e5dcc4479f365f786aeff4"
       - um_ref="2026.05.0"
       - ukca_ref="AM3-2026.03.0"
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.05.000]
+  - _version: [2026.05.001]
   specs:
   - access-am3
   packages:
@@ -15,7 +15,7 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="2026.05.0"
+      - jules_ref="0b6717ebd65c5228c2cae7574b6a80454f6f9ad6"
       - um_ref="2026.05.0"
       - ukca_ref="AM3-2026.03.0"
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.05.001]
+  - _version: [2026.06.000]
   specs:
   - access-am3
   packages:
@@ -15,7 +15,7 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="0734d12dc621f9095050ec2597c93b61ab4fc36d"
+      - jules_ref="bfaec9470846a539efd3fce7464446cb565be13b"
       - um_ref="2026.05.0"
       - ukca_ref="AM3-2026.03.0"
 


### PR DESCRIPTION
The current setup of `cable_surface_types_mod` is not compatible with a library. This brings in the changes from [this JULES PR](https://github.com/ACCESS-NRI/JULES/pull/345), which no longer sets the CABLE surface type indices from namelist, as this is not yet supported by CABLE.

---
:rocket: The latest prerelease `access-am3/pr40-14` at c7be9c8a56c2731982d5672695f876c3dfdae063 is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/40#issuecomment-4704046650 :rocket:















