### PR TITLE
Builds with CABLE as a library

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "1ee53f46d0c417118ee70b3d9ccb54ff8b7941e3",
+  "access-spack-packages": "2026.07.013",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "599c63f96f8ecb9c0847ee2a7378639215f52e53",
+  "access-spack-packages": "cd8bdd99d43b8185f12370a25904211e974c3d3e",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "c29197724cccdc31026533a222620613f3f609b5",
+  "access-spack-packages": "8b472012207432bd8ac9dc4f6b9a0bd7e7969409",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.03.005",
+  "access-spack-packages": "c2df80de8b96ef44b0d5df802a9c9c79e2ceb107",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "cd8bdd99d43b8185f12370a25904211e974c3d3e",
+  "access-spack-packages": "361fcf71d75c5c547e3f32332123598b0168b199",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "361fcf71d75c5c547e3f32332123598b0168b199",
+  "access-spack-packages": "1ee53f46d0c417118ee70b3d9ccb54ff8b7941e3",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.05.005",
+  "access-spack-packages": "599c63f96f8ecb9c0847ee2a7378639215f52e53",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "c2df80de8b96ef44b0d5df802a9c9c79e2ceb107",
+  "access-spack-packages": "c29197724cccdc31026533a222620613f3f609b5",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "8b472012207432bd8ac9dc4f6b9a0bd7e7969409",
+  "access-spack-packages": "5db5180658732a816500f739c52db5a6ab03903c",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "599c63f96f8ecb9c0847ee2a7378639215f52e53",
+  "access-spack-packages": "2026.05.005",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "ed5e226147430274f7aa367998e100d8a8b87ec1",
+  "access-spack-packages": "599c63f96f8ecb9c0847ee2a7378639215f52e53",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "5db5180658732a816500f739c52db5a6ab03903c",
+  "access-spack-packages": "ed5e226147430274f7aa367998e100d8a8b87ec1",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:
-      - '@1c1e944f0609ce3f0bf519d6f4ad9864b3f1c0e2'
+      - '@aaba5ca98516750f331e7083c8806dac2842465a'
       - 'library=access3'
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
       - '@13.1'
       - model="vn13p1-am"
       - jules_ref="0f3f078a10cd4be769fd32711afc626d195fdbb9"
-      - um_ref="937c7995a511190b221be44e50346d007400b902"
+      - um_ref="1002c0c9e5c4f478c8c6931598aed66f2b9306da"
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,6 +19,7 @@ spack:
       - um_ref="37dda5a5047a4ed52bf92ab695e5660ea4a9b1ab"
       - ukca_ref="AM3-2026.03.0"
       - shumlib_ref="2026.06.0"
+      - +cable
       
     cable:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.05.000]
+  - _version: [2026.05.001]
   specs:
   - access-am3
   packages:
@@ -15,9 +15,14 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="2026.05.0"
-      - um_ref="2026.05.0"
+      - jules_ref="0f3f078a10cd4be769fd32711afc626d195fdbb9"
+      - um_ref="6168837aa4e1dc8d1c51ed93a923f7dd09fd5848"
       - ukca_ref="AM3-2026.03.0"
+
+    cable:
+      require:
+      - '@4813a19ceb90ad0192389b8c81fe13568454232e'
+      - 'library=access3'
 
     # Indirect dependencies
     netcdf-c:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:
-      - '@f5662be320dbea21372971734103f1d172524eff'
+      - '@c6fe3e52a801dea5041f24c1b71b0998873a25cb'
       - 'library=access3'
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -18,7 +18,6 @@ spack:
       - jules_ref="0f3f078a10cd4be769fd32711afc626d195fdbb9"
       - um_ref="937c7995a511190b221be44e50346d007400b902"
       - ukca_ref="AM3-2026.03.0"
-    # trigger redeploy
     cable:
       require:
       - '@4813a19ceb90ad0192389b8c81fe13568454232e'

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:
-      - '@a892c05be691939e28b5a3048b904959c9716385'
+      - '@39fc22033dd4c12062cc47c605b1d736e698535c'
       - 'library=access3'
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
       - '@13.1'
       - model="vn13p1-am"
       - jules_ref="0f3f078a10cd4be769fd32711afc626d195fdbb9"
-      - um_ref="43bd9296881d683cce4ddac937980de8a8be6bf6"
+      - um_ref="e23e980f43a0349dd057478a38870fc7e3b89c8c"
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
       - '@13.1'
       - model="vn13p1-am"
       - jules_ref="0f3f078a10cd4be769fd32711afc626d195fdbb9"
-      - um_ref="1002c0c9e5c4f478c8c6931598aed66f2b9306da"
+      - um_ref="43bd9296881d683cce4ddac937980de8a8be6bf6"
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:
-      - '@4813a19ceb90ad0192389b8c81fe13568454232e'
+      - '@git.4813a19ceb90ad0192389b8c81fe13568454232e'
       - 'library=access3'
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
       - '@13.1'
       - model="vn13p1-am"
       - jules_ref="0f3f078a10cd4be769fd32711afc626d195fdbb9"
-      - um_ref="6168837aa4e1dc8d1c51ed93a923f7dd09fd5848"
+      - um_ref="d62f185b90ab5cd2223bed924210d46350a80817"
       - ukca_ref="AM3-2026.03.0"
 
     cable:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="f347f33fba58a50d9d03b8ebc1b2c0b37dbaa610"
+      - jules_ref="17607374cda8e75f73cee4601444cce6d3a4e8b1"
       - um_ref="fdbdfbf0168bfe50d3b6e10391d4e6e8972a3dc2"
       - ukca_ref="AM3-2026.03.0"
     cable:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,12 +15,12 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="0f3f078a10cd4be769fd32711afc626d195fdbb9"
-      - um_ref="1fe38385fe02a0aa4dc5b830564f04a34e2a3eb0"
+      - jules_ref="f347f33fba58a50d9d03b8ebc1b2c0b37dbaa610"
+      - um_ref="594b5e369fa0d74ab7232fa130fbc8a675c4c8ac"
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:
-      - '@911c2b39fe4a7128ec42c001bc54600379229bff'
+      - '@f5662be320dbea21372971734103f1d172524eff'
       - 'library=access3'
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:
-      - '@aaba5ca98516750f331e7083c8806dac2842465a'
+      - '@43bd6c67912e33ad2f34bb119a3b12d3342b47bd'
       - 'library=access3'
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.06.002]
+  - _version: [2026.07.000]
   specs:
   - access-am3
   packages:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,12 +15,12 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="512b8bf22acd33cc0b1682a34b3b991ae46ad4c5"
-      - um_ref="4367ad344aa28a35e9dc6369d7b7c8508cd0e66a"
+      - jules_ref="b3bffa33be1c8b4dc46a9b9b67b9d100a066d1a2"
+      - um_ref="37dda5a5047a4ed52bf92ab695e5660ea4a9b1ab"
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:
-      - '@a892c05be691939e28b5a3048b904959c9716385'
+      - '@1c1e944f0609ce3f0bf519d6f4ad9864b3f1c0e2'
       - 'library=access3'
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
       - '@13.1'
       - model="vn13p1-am"
       - jules_ref="512b8bf22acd33cc0b1682a34b3b991ae46ad4c5"
-      - um_ref="4367ad344aa28a35e9dc6369d7b7c8508cd0e66a"
+      - um_ref="7cf9fef022ac7c13ef394ae34712cc47d31c507d"
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="27b49b0909a536dc99048eadf6c6948798767eb7"
+      - jules_ref="2b4a750d6657e0270434cb22fc24a61a258de68f"
       - um_ref="37dda5a5047a4ed52bf92ab695e5660ea4a9b1ab"
       - ukca_ref="AM3-2026.03.0"
     cable:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
       - '@13.1'
       - model="vn13p1-am"
       - jules_ref="0f3f078a10cd4be769fd32711afc626d195fdbb9"
-      - um_ref="bcb34cd7419e2a8acbbebd6e675e81534e8bf91e"
+      - um_ref="1fe38385fe02a0aa4dc5b830564f04a34e2a3eb0"
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="17607374cda8e75f73cee4601444cce6d3a4e8b1"
+      - jules_ref="9ac30b6eaf3266a46d16fb2db13c84fb542956f7"
       - um_ref="fdbdfbf0168bfe50d3b6e10391d4e6e8972a3dc2"
       - ukca_ref="AM3-2026.03.0"
     cable:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
       - '@13.1'
       - model="vn13p1-am"
       - jules_ref="f347f33fba58a50d9d03b8ebc1b2c0b37dbaa610"
-      - um_ref="594b5e369fa0d74ab7232fa130fbc8a675c4c8ac"
+      - um_ref="fdbdfbf0168bfe50d3b6e10391d4e6e8972a3dc2"
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:
-      - '@git.4813a19ceb90ad0192389b8c81fe13568454232e'
+      - '@911c2b39fe4a7128ec42c001bc54600379229bff'
       - 'library=access3'
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
       - '@13.1'
       - model="vn13p1-am"
       - jules_ref="0f3f078a10cd4be769fd32711afc626d195fdbb9"
-      - um_ref="e23e980f43a0349dd057478a38870fc7e3b89c8c"
+      - um_ref="78fbe391171114ee99b69ce4d95388042276a95a"
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
       - '@13.1'
       - model="vn13p1-am"
       - jules_ref="005602fbc674864e2dc39ef532aa046bbf7aab98"
-      - um_ref="fdbdfbf0168bfe50d3b6e10391d4e6e8972a3dc2"
+      - um_ref="4367ad344aa28a35e9dc6369d7b7c8508cd0e66a"
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -23,7 +23,7 @@ spack:
       
     cable:
       require:
-      - '@2026.07.000'
+      - '@git.2026.07.000'
       - 'library=access3'
 
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,7 +20,7 @@ spack:
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:
-      - '@8d4ebc66c56763219437a40c1b1c3f9c3524a789'
+      - '@4d6818152b48eb8c0167a78b86bf2dccd7742b87'
       - 'library=access3'
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
       - '@13.1'
       - model="vn13p1-am"
       - jules_ref="0f3f078a10cd4be769fd32711afc626d195fdbb9"
-      - um_ref="d62f185b90ab5cd2223bed924210d46350a80817"
+      - um_ref="937c7995a511190b221be44e50346d007400b902"
       - ukca_ref="AM3-2026.03.0"
 
     cable:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,8 +15,8 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="2b4a750d6657e0270434cb22fc24a61a258de68f"
-      - um_ref="37dda5a5047a4ed52bf92ab695e5660ea4a9b1ab"
+      - jules_ref="2026.07.000"
+      - um_ref="2026.07.000"
       - ukca_ref="AM3-2026.03.0"
       - shumlib_ref="2026.06.0"
       - +cable

--- a/spack.yaml
+++ b/spack.yaml
@@ -18,7 +18,7 @@ spack:
       - jules_ref="0f3f078a10cd4be769fd32711afc626d195fdbb9"
       - um_ref="937c7995a511190b221be44e50346d007400b902"
       - ukca_ref="AM3-2026.03.0"
-
+    # trigger redeploy
     cable:
       require:
       - '@4813a19ceb90ad0192389b8c81fe13568454232e'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="b3bffa33be1c8b4dc46a9b9b67b9d100a066d1a2"
+      - jules_ref="27b49b0909a536dc99048eadf6c6948798767eb7"
       - um_ref="37dda5a5047a4ed52bf92ab695e5660ea4a9b1ab"
       - ukca_ref="AM3-2026.03.0"
     cable:

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.05.001]
+  - _version: [2026.06.002]
   specs:
   - access-am3
   packages:
@@ -15,12 +15,12 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="87647b9b9377e9fcc528d45728a184e73a72fba2"
+      - jules_ref="512b8bf22acd33cc0b1682a34b3b991ae46ad4c5"
       - um_ref="4367ad344aa28a35e9dc6369d7b7c8508cd0e66a"
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:
-      - '@4d6818152b48eb8c0167a78b86bf2dccd7742b87'
+      - '@a892c05be691939e28b5a3048b904959c9716385'
       - 'library=access3'
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="9ac30b6eaf3266a46d16fb2db13c84fb542956f7"
+      - jules_ref="005602fbc674864e2dc39ef532aa046bbf7aab98"
       - um_ref="fdbdfbf0168bfe50d3b6e10391d4e6e8972a3dc2"
       - ukca_ref="AM3-2026.03.0"
     cable:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
       - '@13.1'
       - model="vn13p1-am"
       - jules_ref="0f3f078a10cd4be769fd32711afc626d195fdbb9"
-      - um_ref="0803d516369f00d6d547a7f039310822922424e5"
+      - um_ref="bcb34cd7419e2a8acbbebd6e675e81534e8bf91e"
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
       - '@13.1'
       - model="vn13p1-am"
       - jules_ref="0f3f078a10cd4be769fd32711afc626d195fdbb9"
-      - um_ref="78fbe391171114ee99b69ce4d95388042276a95a"
+      - um_ref="0803d516369f00d6d547a7f039310822922424e5"
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,12 +15,12 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="005602fbc674864e2dc39ef532aa046bbf7aab98"
+      - jules_ref="87647b9b9377e9fcc528d45728a184e73a72fba2"
       - um_ref="4367ad344aa28a35e9dc6369d7b7c8508cd0e66a"
       - ukca_ref="AM3-2026.03.0"
     cable:
       require:
-      - '@c6fe3e52a801dea5041f24c1b71b0998873a25cb'
+      - '@8d4ebc66c56763219437a40c1b1c3f9c3524a789'
       - 'library=access3'
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -23,7 +23,7 @@ spack:
       
     cable:
       require:
-      - '@43bd6c67912e33ad2f34bb119a3b12d3342b47bd'
+      - '@2026.07.000'
       - 'library=access3'
 
 


### PR DESCRIPTION
See title. The definitive build which includes CABLE as library instead of source code.

---
:rocket: The latest prerelease `access-am3/pr41-51` at 72abda45cb84ef4f90efd669ef6d97ce83254474 is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/41#issuecomment-5140048655 :rocket:



















































