### PR TITLE
Update shumlib to use the head of the upstream.

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.03.005",
+  "access-spack-packages": "2026.05.005",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.05.000]
+  - _version: [2026.06.000]
   specs:
   - access-am3
   packages:
@@ -18,6 +18,7 @@ spack:
       - jules_ref="2026.05.0"
       - um_ref="2026.05.0"
       - ukca_ref="AM3-2026.03.0"
+      - shumlib_ref="8ea99619084c0fa9fbe3324998c9ea10f55cfdac"
 
     # Indirect dependencies
     netcdf-c:


### PR DESCRIPTION
Move to the head of `shumlib` upstream, in preparation for merging in the extrapolation fix identified [here](https://github.com/ACCESS-NRI/access-am3-configs/issues/201) (thanks @paocorrales). We want to be up to date with the upstream before we apply the fix, and attempt to merge the fix into said upstream.

---
:rocket: The latest prerelease `access-am3/pr45-3` at db40ac7ca28bff3f5f9425e0710c8c3e0473c4bd is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/45#issuecomment-4655417999 :rocket:


