### PR TITLE
Pull new spack-packages version which supports fetching UM commits

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.03.005",
+  "access-spack-packages": "2026.05.005",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.05.000]
+  - _version: [2026.06.000]
   specs:
   - access-am3
   packages:


### PR DESCRIPTION
As title states, there was a bug in the UM build system that meant that it wasn't correctly checking out commits for the UM.

---
:rocket: The latest prerelease `access-am3/pr46-1` at 7eb28a8e4f3d42c468d35478a11e43eb9db33de1 is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/46#issuecomment-4654816742 :rocket:
