### PR TITLE
Testing vn13.8

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.06.001]
+  - _version: [2026.06.002]
   specs:
   - access-am3
   packages:

--- a/spack.yaml
+++ b/spack.yaml
@@ -36,7 +36,7 @@ spack:
 
     gcom:
       require:
-      - '@7.9'
+      - '@8.4'
 
     openmpi:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,8 +15,8 @@ spack:
       require:
       - '@13.8'
       - model="vn13p1-am"
-      - jules_ref="e79c70973ac08e6c5322e716a537eb0e94f121dd"
-      - um_ref="6ec17fb4dc6752332b5337784feb2d9443745578"
+      - jules_ref="492aae42d33da81c3399eac46e5b114051076631"
+      - um_ref="cc4adedbb25f54cc22da93e2e2fd1c045ca6ba34"
       - ukca_ref="AM3-2026.03.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,8 +15,8 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="2026.06.0"
-      - um_ref="2026.05.0"
+      - jules_ref="e79c70973ac08e6c5322e716a537eb0e94f121dd"
+      - um_ref="6ec17fb4dc6752332b5337784feb2d9443745578"
       - ukca_ref="AM3-2026.03.0"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,7 +13,7 @@ spack:
     # Direct dependencies
     um:
       require:
-      - '@13.1'
+      - '@13.8'
       - model="vn13p1-am"
       - jules_ref="e79c70973ac08e6c5322e716a537eb0e94f121dd"
       - um_ref="6ec17fb4dc6752332b5337784feb2d9443745578"

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
       - model="vn13p1-am"
       - jules_ref="492aae42d33da81c3399eac46e5b114051076631"
       - um_ref="cc4adedbb25f54cc22da93e2e2fd1c045ca6ba34"
-      - ukca_ref="AM3-2026.03.0"
+      - ukca_ref="7a828610d148a78247b701c570148356140ea4c1"
 
     # Indirect dependencies
     netcdf-c:


### PR DESCRIPTION
Updated jules_ref and um_ref to specific commit hashes for complementary PRs for UM 13.8 testing.

DO NOT MERGE YET.

---
:rocket: The latest prerelease `access-am3/pr50-6` at ff528f45fdf5a569b8bbb552f3bc755e681a2979 is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/50#issuecomment-4747374162 :rocket:






