### PR TITLE
`!update-configs`: Now supports `rose-cylc`

### DIFF
--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -34,8 +34,7 @@ jobs:
     if: startsWith(github.event.comment.body, '!update-configs') && github.event.issue.pull_request
     uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v8
     with:
-      model: ${{ vars.NAME }}
-      auto-configs-pr-schema-version: 1-0-0
+      auto-configs-pr-schema-version: 1-0-1
     permissions:
       pull-requests: write
     secrets:

--- a/config/auto-configs-pr.json
+++ b/config/auto-configs-pr.json
@@ -1,13 +1,15 @@
 {
-  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-0.json",
+  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-1.json",
   "profiles": {
 
     "default": {
       "configs_repo": "ACCESS-NRI/access-am3-configs",
+      "target": "gadi",
+      "workflow_manager": "rose-cylc",
       "configs": {
         "dev-n96e": {
           "checks": {
-            "repro": true
+            "repro": false
           }
         }
       }


### PR DESCRIPTION
References ACCESS-NRI/build-cd#400

## Background

`ACCESS-AM3` (and by extension `access-am3-configs`) is special - it uses `rose-cylc` as a workflow manager rather than `payu`, which was unsupported by `!update-configs`...until today! (see linked issue/PRs) 

## The PR

- **config/auto-configs-pr.json: Add  target and rose-cylc workflow_manager**
- **[no ci] ci-command: Update schema to 1-0-1, remove deprecated model input**
