### PR TITLE
Test vn13.8 with shumlib fix for n512e

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "ff1cd5a41a5f9a85929f32929ea2bda0bac83437",
+  "access-spack-packages": "bd7fc80e29ebbf0bec5492d2688ffe3cbbdda00a",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "bd7fc80e29ebbf0bec5492d2688ffe3cbbdda00a",
+  "access-spack-packages": "2026.07.008",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.05.005",
+  "access-spack-packages": "ff1cd5a41a5f9a85929f32929ea2bda0bac83437",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,7 +14,7 @@ spack:
     um:
       require:
       - '@13.8'
-      - model="vn13"
+      - model="vn13p8-am"
       - jules_ref="AM3-dev-vn13.8"
       - um_ref="AM3-dev-vn13.8"
       - ukca_ref="7a828610d148a78247b701c570148356140ea4c1"

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.06.003]
+  - _version: [2026.06.004]
   specs:
   - access-am3
   packages:
@@ -18,6 +18,7 @@ spack:
       - jules_ref="AM3-dev-vn13.8"
       - um_ref="AM3-dev-vn13.8"
       - ukca_ref="7a828610d148a78247b701c570148356140ea4c1"
+      - shumlib_ref="2026.06.0"
 
     # Indirect dependencies
     netcdf-c:

--- a/spack.yaml
+++ b/spack.yaml
@@ -18,7 +18,7 @@ spack:
       - jules_ref="AM3-dev-vn13.8"
       - um_ref="AM3-dev-vn13.8"
       - ukca_ref="7a828610d148a78247b701c570148356140ea4c1"
-      - shumlib_ref="2026.06.0"
+      - shumlib_ref="e409db21f9ed362e6947d9aa9f5694a123449dcb"
 
     # Indirect dependencies
     netcdf-c:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
       - '@13.8'
       - model="vn13p1-am"
       - jules_ref="AM3-dev-vn13.8"
-      - um_ref="AM3-dev-vn.13.8"
+      - um_ref="AM3-dev-vn13.8"
       - ukca_ref="7a828610d148a78247b701c570148356140ea4c1"
 
     # Indirect dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,7 +14,7 @@ spack:
     um:
       require:
       - '@13.8'
-      - model="vn13p1-am"
+      - model="vn13"
       - jules_ref="AM3-dev-vn13.8"
       - um_ref="AM3-dev-vn13.8"
       - ukca_ref="7a828610d148a78247b701c570148356140ea4c1"

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,18 +6,18 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.06.001]
+  - _version: [2026.06.003]
   specs:
   - access-am3
   packages:
     # Direct dependencies
     um:
       require:
-      - '@13.1'
+      - '@13.8'
       - model="vn13p1-am"
-      - jules_ref="2026.06.0"
-      - um_ref="2026.05.0"
-      - ukca_ref="AM3-2026.03.0"
+      - jules_ref="AM3-dev-vn13.8"
+      - um_ref="AM3-dev-vn.13.8"
+      - ukca_ref="7a828610d148a78247b701c570148356140ea4c1"
 
     # Indirect dependencies
     netcdf-c:
@@ -36,7 +36,7 @@ spack:
 
     gcom:
       require:
-      - '@7.9'
+      - '@8.4'
 
     openmpi:
       require:


### PR DESCRIPTION
This PR replaces #53 and is based on #51

It's meant to test the n512e configuration (in this PR https://github.com/ACCESS-NRI/access-am3-configs/pull/276) with the UM v13.8.

---
:rocket: The latest prerelease `access-am3/pr54-10` at 021490e853cab611b6890b3db709acd910e9757c is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/54#issuecomment-4988994041 :rocket:










