### PR TITLE
Update spack packages with sapphire rapids

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2e4fa2bbc1507b2c27d47f317b25ec0b78de0222",
+  "access-spack-packages": "2026.07.008",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.07.008",
+  "access-spack-packages": "2e4fa2bbc1507b2c27d47f317b25ec0b78de0222",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
       - '@13.8'
       - model="vn13p8-am"
       - jules_ref="AM3-dev-vn13.8"
-      - um_ref="AM3-dev-vn13.8"
+      - um_ref="677558e825f964ca2fdaca500cb92c6499a30717"
       - ukca_ref="7a828610d148a78247b701c570148356140ea4c1"
       - shumlib_ref="e409db21f9ed362e6947d9aa9f5694a123449dcb"
       - fcflags_overrides="-march=sapphirerapids -mtune=sapphirerapids"

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.06.004]
+  - _version: [2026.06.005]
   specs:
   - access-am3
   packages:

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,6 +19,7 @@ spack:
       - um_ref="AM3-dev-vn13.8"
       - ukca_ref="7a828610d148a78247b701c570148356140ea4c1"
       - shumlib_ref="e409db21f9ed362e6947d9aa9f5694a123449dcb"
+      - fcflags_overrides="-march=sapphirerapids -mtune=sapphirerapids"
 
     # Indirect dependencies
     netcdf-c:


### PR DESCRIPTION
Test build with sapphire rapids flags.

---
:rocket: The latest prerelease `access-am3/pr55-5` at 8853e0ceb747f7bd356feedf41b012133c3cad0d is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/55#issuecomment-5086689985 :rocket:




