### PR TITLE
Remove eccodes and DR_HOOK

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -19,6 +19,8 @@ spack:
       - um_ref="2026.05.0"
       - ukca_ref="AM3-2026.03.0"
       - shumlib_ref="2026.06.0"
+      - -eccodes
+      - -DR_HOOK
 
     # Indirect dependencies
     netcdf-c:

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.06.002]
+  - _version: [2026.07.000]
   specs:
   - access-am3
   packages:
@@ -19,8 +19,8 @@ spack:
       - um_ref="2026.05.0"
       - ukca_ref="AM3-2026.03.0"
       - shumlib_ref="2026.06.0"
-      - -eccodes
-      - -DR_HOOK
+      - ~eccodes
+      - ~DR_HOOK
 
     # Indirect dependencies
     netcdf-c:


### PR DESCRIPTION
See title. We don't want them to be included, based on the spack packages' [vn13p5-am/rose-app.conf](https://github.com/ACCESS-NRI/access-spack-packages/blob/api-v2/spack_repo/access/nri/packages/um/model/vn13p1-am/rose-app.conf).

---
:rocket: The latest prerelease `access-am3/pr59-1` at d8cac394ec25b366facee272de7e0897b95b814d is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/59#issuecomment-5137672050 :rocket:

