### PR TITLE
Test new spack-packages

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.05.005",
+  "access-spack-packages": "0d518ac39242041f09f554eccb9aa0e5c5547422",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.06.002]
+  - _version: [2026.07.000]
   specs:
   - access-am3
   packages:


### PR DESCRIPTION
Test changing the default value for variants to be "default", so that we get more descriptive build concretizations.

---
:rocket: The latest prerelease `access-am3/pr60-1` at 56f9bbe03bb52e61b9c3b28f094e795f585d606a is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/60#issuecomment-5139878989 :rocket:

