### PR TITLE
Update version numbers in spack.yaml

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.07.000]
+  - _version: [2026.08.000]
   specs:
   - access-am3
   packages:
@@ -15,8 +15,8 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="2026.07.000"
-      - um_ref="2026.07.000"
+      - jules_ref="2026.08.000"
+      - um_ref="2026.08.000"
       - ukca_ref="AM3-2026.03.0"
       - shumlib_ref="2026.06.0"
       - +cable


### PR DESCRIPTION
Updated UM and JULES refs to point at 2026.08.000 releases.

---
:rocket: The latest prerelease `access-am3/pr62-1` at e003aba5b4801e1cf7b1bf77733650ac89d3d8f7 is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/62#issuecomment-5187240317 :rocket:
