### PR TITLE
Update jules_ref to a specific commit hash

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-am3]
-  - _version: [2026.08.000]
+  - _version: [2026.08.001]
   specs:
   - access-am3
   packages:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       require:
       - '@13.1'
       - model="vn13p1-am"
-      - jules_ref="2026.08.000"
+      - jules_ref="3ffed4714407a5c18501a0c3bb7c31293106d86a"
       - um_ref="2026.08.000"
       - ukca_ref="AM3-2026.03.0"
       - shumlib_ref="2026.06.0"


### PR DESCRIPTION
This tests the fix for the namelist derived type order.

---
:rocket: The latest prerelease `access-am3/pr63-1` at fe87c130690caa514ed14f90880f6fbfeffaca1a is here: https://github.com/ACCESS-NRI/ACCESS-AM3/pull/63#issuecomment-5198946356 :rocket:

